### PR TITLE
Pull all branches in the repository

### DIFF
--- a/src/Commands/PullCommand.cs
+++ b/src/Commands/PullCommand.cs
@@ -58,7 +58,7 @@ namespace GitPull
                 var progress = new Progress<string>(line =>
                 {
                     ThreadHelper.ThrowIfNotOnUIThread();
-                    pane.Value.OutputStringThreadSafe(line + Environment.NewLine);
+                    pane.Value.OutputString(line + Environment.NewLine);
                 });
 
                 SyncRepositoryAsync(solutionDir, progress).FileAndForget("madskristensen/gitpull");

--- a/src/Commands/PullCommand.cs
+++ b/src/Commands/PullCommand.cs
@@ -55,13 +55,20 @@ namespace GitPull
                     return package.GetOutputPane(Guid.NewGuid(), "Git Pull");
                 });
 
+                var outputText = false;
                 var progress = new Progress<string>(line =>
                 {
                     ThreadHelper.ThrowIfNotOnUIThread();
                     pane.Value.OutputString(line + Environment.NewLine);
+                    outputText = true;
                 });
 
                 SyncRepositoryAsync(solutionDir, progress).FileAndForget("madskristensen/gitpull");
+
+                if (!outputText)
+                {
+                    dte.StatusBar.Text = "No branches require syncing";
+                }
             }
             catch (Exception ex)
             {

--- a/src/Commands/PullCommand.cs
+++ b/src/Commands/PullCommand.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Diagnostics;
 using System.ComponentModel.Design;
+using EnvDTE;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
+using Process = System.Diagnostics.Process;
 
 namespace GitPull
 {
@@ -16,7 +22,7 @@ namespace GitPull
             Assumes.Present(commandService);
 
             var cmdId = new CommandID(PackageGuids.guidGitPullPackageCmdSet, PackageIds.PullCommandId);
-            var cmd = new MenuCommand((s, e) => Execute(commandService), cmdId)
+            var cmd = new MenuCommand((s, e) => Execute(package), cmdId)
             {
                 Supported = false
             };
@@ -24,20 +30,89 @@ namespace GitPull
             commandService.AddCommand(cmd);
         }
 
-        public static void Execute(OleMenuCommandService commandService)
+        public static void Execute(AsyncPackage package)
         {
-            var guid = new Guid("{57735D06-C920-4415-A2E0-7D6E6FBDFA99}");
-            int id = 0x1033;
-            var cmdId = new CommandID(guid, id);
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             try
             {
-                _ = commandService.GlobalInvoke(cmdId);
+                var serviceProvider = package as IServiceProvider;
+                Assumes.Present(serviceProvider);
+                var dte = serviceProvider.GetService(typeof(DTE)) as DTE;
+                Assumes.Present(dte);
+
+                var solutionDir = FindSolutionDirectory(dte);
+                if (solutionDir == null)
+                {
+                    return;
+                }
+
+                var pane = new Lazy<IVsOutputWindowPane>(() => package.GetOutputPane(Guid.NewGuid(), "Git Pull"));
+                var progress = new Progress<string>(line =>
+                {
+                    ThreadHelper.ThrowIfNotOnUIThread();
+                    pane.Value.OutputStringThreadSafe(line + Environment.NewLine);
+                });
+
+                SyncRepositoryAsync(solutionDir, progress).FileAndForget("madskristensen/gitpull");
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.Write(ex);
+                Debug.Write(ex);
             }
+        }
+
+        static async Task SyncRepositoryAsync(string solutionDir, Progress<string> progress)
+        {
+            var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var exeFile = Path.Combine(dir, "hub.exe");
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = exeFile,
+                Arguments = "sync",
+                WorkingDirectory = solutionDir,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+
+            var process = Process.Start(startInfo);
+            await Task.WhenAll(
+                ReadAllAsync(process.StandardOutput, progress),
+                ReadAllAsync(process.StandardError, progress));
+        }
+
+        static async Task ReadAllAsync(StreamReader reader, IProgress<string> progress)
+        {
+            while (true)
+            {
+                var line = await reader.ReadLineAsync();
+                if (line == null)
+                {
+                    break;
+                }
+
+                progress.Report(line);
+            }
+        }
+
+        static string FindSolutionDirectory(DTE dte)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var path = dte.Solution.FileName;
+            if (Directory.Exists(path))
+            {
+                return path;
+            }
+
+            if (File.Exists(path))
+            {
+                return Path.GetDirectoryName(path);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Commands/PullCommand.cs
+++ b/src/Commands/PullCommand.cs
@@ -47,7 +47,14 @@ namespace GitPull
                     return;
                 }
 
-                var pane = new Lazy<IVsOutputWindowPane>(() => package.GetOutputPane(Guid.NewGuid(), "Git Pull"));
+                var pane = new Lazy<IVsOutputWindowPane>(() =>
+                {
+                    ThreadHelper.ThrowIfNotOnUIThread();
+                    var window = dte.Windows.Item(EnvDTE.Constants.vsWindowKindOutput);
+                    window.Activate();
+                    return package.GetOutputPane(Guid.NewGuid(), "Git Pull");
+                });
+
                 var progress = new Progress<string>(line =>
                 {
                     ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/GitPull.csproj
+++ b/src/GitPull.csproj
@@ -82,6 +82,9 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="EnvDTE">
+      <Version>8.0.2</Version>
+    </PackageReference>
     <PackageReference Include="Madskristensen.VSSDK.Resourcer">
       <Version>1.0.10</Version>
     </PackageReference>
@@ -108,6 +111,10 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Content Include="hub.exe">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\Icon.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/src/GitPullAutoloadPackage.cs
+++ b/src/GitPullAutoloadPackage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -63,10 +62,9 @@ namespace GitPull
                     return;
                 }
 
-                var commandService = await GetServiceAsync((typeof(IMenuCommandService))) as OleMenuCommandService;
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                PullCommand.Execute(commandService);
+                PullCommand.Execute(this);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Rather than pulling just the current branch, pull all branches in the repository and delete branches that appear merged and have had their upstream branch deleted.

This means that if the user changes to a different branch, this branch will already be up to date and there will be no need to pull again with the solution loaded (which can be expensive and trigger project/solution reloads).

This implementation embeds [hub](https://github.com/github/hub) and executes the `sync` command, see:
https://hub.github.com/hub-sync.1.html

- If the local branch is outdated, fast-forward it;
- If the local branch contains unpushed work, warn about it;
- If the branch seems merged and its upstream branch was deleted, delete it.

![image](https://user-images.githubusercontent.com/11719160/50191128-4736f200-0324-11e9-8e18-b15a351b0bfc.png)

When text is written the the `Output` pane before it has been activated, the window can appear blank. Here is an example form the `Learn the Shortcut` extension:

![image](https://user-images.githubusercontent.com/11719160/50247491-e7962080-03cf-11e9-95dd-2845009dd17c.png)

To avoid this and let the user know when something is happening, this PR will activate the `Output` window immediately before creating a pane and writing any output.

If no branches require syncing and there is nothing to output, the following message will appear on the status bar:

![image](https://user-images.githubusercontent.com/11719160/50247644-64c19580-03d0-11e9-9d35-86fd26bb802a.png)
